### PR TITLE
Added first step towards tournament mode: rankings can now be calculated

### DIFF
--- a/src/main/java/ch/squix/extraleague/model/match/Match.java
+++ b/src/main/java/ch/squix/extraleague/model/match/Match.java
@@ -29,8 +29,13 @@ public class Match {
 	private List<String> scorers = new ArrayList<>();
 	
 	@Index
+	private List<String> tags = new ArrayList<>();
+	
+	@Index
 	private Date startDate;
 	private Date endDate;
+	
+	@Index
 	private String table;
 	private Integer matchIndex;
 	
@@ -144,6 +149,12 @@ public class Match {
 	}
 	public void setWinPointsTeamB(Integer winPointsTeamB) {
 		this.winPointsTeamB = winPointsTeamB;
+	}
+	public List<String> getTags() {
+		return tags;
+	}
+	public void setTags(List<String> tags) {
+		this.tags = tags;
 	}
 
 }

--- a/src/main/java/ch/squix/extraleague/model/ranking/RankingService.java
+++ b/src/main/java/ch/squix/extraleague/model/ranking/RankingService.java
@@ -40,6 +40,14 @@ public class RankingService {
 		Calendar calendar = Calendar.getInstance();
 		calendar.add(Calendar.DATE, -30);
 		List<Match> matchesList = ofy().load().type(Match.class).filter("startDate > ", calendar.getTime()).list();
+		Ranking ranking = calculateRankingFromMatches(matchesList);
+
+		
+		ofy().save().entities(ranking);
+
+	}
+
+	public static Ranking calculateRankingFromMatches(List<Match> matchesList) {
 		Matches matches = new Matches();
 		matches.setMatches(matchesList);
 		
@@ -83,10 +91,7 @@ public class RankingService {
 		Ranking ranking = new Ranking();
 		ranking.setCreatedDate(new Date());
 		ranking.setPlayerRankings(rankings);
-
-		
-		ofy().save().entities(ranking);
-
+		return ranking;
 	}
 
 

--- a/src/main/java/ch/squix/extraleague/rest/ExtraLeagueRestApplication.java
+++ b/src/main/java/ch/squix/extraleague/rest/ExtraLeagueRestApplication.java
@@ -21,6 +21,7 @@ import ch.squix.extraleague.rest.notification.NotificationTokenResource;
 import ch.squix.extraleague.rest.ping.PingResource;
 import ch.squix.extraleague.rest.player.PlayerRessource;
 import ch.squix.extraleague.rest.player.PlayersRessource;
+import ch.squix.extraleague.rest.ranking.RankingByTagResource;
 import ch.squix.extraleague.rest.ranking.RankingResource;
 import ch.squix.extraleague.rest.ranking.RankingServiceResource;
 import ch.squix.extraleague.rest.result.SummaryResource;
@@ -49,6 +50,7 @@ public class ExtraLeagueRestApplication extends Application {
         router.attach("/ping", PingResource.class);
         router.attach("/tables", TablesResource.class);
         router.attach("/ranking", RankingResource.class);
+        router.attach("/rankings/tags/{tag}", RankingByTagResource.class);
         router.attach("/tables/{table}/games", GamesResource.class);
         router.attach("/openGames", OpenGamesResource.class);
         router.attach("/playedGames", PlayedGamesResource.class);

--- a/src/main/java/ch/squix/extraleague/rest/games/GamesResource.java
+++ b/src/main/java/ch/squix/extraleague/rest/games/GamesResource.java
@@ -65,7 +65,7 @@ public class GamesResource extends ServerResource {
 	}
 
 	public List<Match> createMatches(Game game) {
-	        Ranking currentRanking = ofy().load().type(Ranking.class).order("-createdDate").first().now();
+	    Ranking currentRanking = ofy().load().type(Ranking.class).order("-createdDate").first().now();
 		List<String> players = game.getPlayers();
 		List<Match> matches = new ArrayList<>();
 		for (int gameIndex = 0; gameIndex < 4; gameIndex++) {
@@ -78,6 +78,7 @@ public class GamesResource extends ServerResource {
 			match.setTeamBScore(0);
 			match.setPlayers(players);
 			match.setTable(game.getTable());
+			match.getTags().add(game.getTable());
 			match.setMatchIndex(gameIndex);
 			if (currentRanking != null) {
 			    Double winProbabilityTeamA = EloUtil.getExpectedOutcome(getTeamRanking(currentRanking, match.getTeamA()), getTeamRanking(currentRanking, match.getTeamB()));

--- a/src/main/java/ch/squix/extraleague/rest/maintenance/MigrateMatchesResource.java
+++ b/src/main/java/ch/squix/extraleague/rest/maintenance/MigrateMatchesResource.java
@@ -5,19 +5,16 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import org.restlet.resource.Get;
-import org.restlet.resource.Post;
 import org.restlet.resource.ServerResource;
 
 import ch.squix.extraleague.model.game.Game;
 import ch.squix.extraleague.model.match.Match;
-import ch.squix.extraleague.model.ranking.RankingService;
 import ch.squix.extraleague.rest.games.GamesResource;
 
 
@@ -29,12 +26,18 @@ public class MigrateMatchesResource extends ServerResource {
 	@Get(value = "json")
 	public String execute() throws UnsupportedEncodingException {
 		long t1 = System.currentTimeMillis();
+		List<Game> games = ofy().load().type(Game.class).list();
+		Map<Long, Game> gameMap = new HashMap<>();
+		for (Game game : games) {
+			gameMap.put(game.getId(), game);
+		}
 		List<Match> matches = ofy().load().type(Match.class).list();
 		for (Match match: matches) {
-			List<String> players = new ArrayList<>();
-			players.addAll(Arrays.asList(match.getTeamA()));
-			players.addAll(Arrays.asList(match.getTeamB()));
-			match.setPlayers(players);
+			Game game = gameMap.get(match.getGameId());
+			if (game!= null) {
+				match.setTable(game.getTable());
+				match.getTags().add(game.getTable());
+			}
 		}
 		ofy().save().entities(matches);
 		return "OK in " + ((System.currentTimeMillis() - t1) / 1000) + "s";

--- a/src/main/java/ch/squix/extraleague/rest/matches/MatchesResource.java
+++ b/src/main/java/ch/squix/extraleague/rest/matches/MatchesResource.java
@@ -57,7 +57,6 @@ public class MatchesResource extends ServerResource {
 		match.setTeamAScore(dto.getTeamAScore());
 		match.setTeamBScore(dto.getTeamBScore());
 		match.setScorers(dto.getScorers());
-		match.setTable(dto.getTable());
 		if (match.getTeamAScore() >= 5 || match.getTeamBScore() >= 5) {
 			log.info("Game is finished");
 			match.setEndDate(new Date());

--- a/src/main/java/ch/squix/extraleague/rest/ranking/RankingByTagResource.java
+++ b/src/main/java/ch/squix/extraleague/rest/ranking/RankingByTagResource.java
@@ -1,0 +1,35 @@
+package ch.squix.extraleague.rest.ranking;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import org.restlet.resource.Get;
+import org.restlet.resource.ServerResource;
+
+import ch.squix.extraleague.model.match.Match;
+import ch.squix.extraleague.model.ranking.Ranking;
+import ch.squix.extraleague.model.ranking.RankingService;
+
+public class RankingByTagResource extends ServerResource {
+	
+	@Get(value = "json")
+	public List<RankingDto> execute() throws UnsupportedEncodingException {
+		String tag = (String) this.getRequestAttributes().get("tag");
+		Calendar calendar = Calendar.getInstance();
+		calendar.add(Calendar.DATE, -30);
+		List<Match> matches = ofy().load().type(Match.class).filter("tags =", tag).filter("startDate > ", calendar.getTime()).list();
+		Ranking ranking = RankingService.calculateRankingFromMatches(matches);
+		if (ranking == null) {
+			return new ArrayList<>();
+		}
+		return RankingDtoMapper.convertToDto(ranking);
+	}
+
+
+
+
+}

--- a/src/main/java/ch/squix/extraleague/rest/tables/TablesResource.java
+++ b/src/main/java/ch/squix/extraleague/rest/tables/TablesResource.java
@@ -12,7 +12,12 @@ public class TablesResource extends ServerResource {
 	
 	@Get(value = "json")
 	public TablesDto[] execute() throws UnsupportedEncodingException {
-		return new TablesDto[] {new TablesDto("Park"), new TablesDto("Albis"), new TablesDto("Bern"), new TablesDto("Skopje")};
+		return new TablesDto[] {
+				new TablesDto("Park"), 
+				new TablesDto("Albis"), 
+				new TablesDto("Bern"), 
+				new TablesDto("Skopje"), 
+				new TablesDto("Rigi")};
 	}
 
 }

--- a/src/main/webapp/js/extraleague.js
+++ b/src/main/webapp/js/extraleague.js
@@ -32,6 +32,10 @@ angular.module('Extraleague', ['ngResource', 'ngRoute', 'ngTouch', 'PlayerMappin
            controller : 'RankingController',
            templateUrl : 'partials/ranking.html'
         })
+        .when('/ranking/tag/:tag', {
+        	controller : 'RankingByTagController',
+        	templateUrl : 'partials/ranking.html'
+        })
         .when('/player/:player', {
            controller : 'PlayerController',
            templateUrl : 'partials/player.html'
@@ -67,6 +71,9 @@ angular.module('Extraleague', ['ngResource', 'ngRoute', 'ngTouch', 'PlayerMappin
     }])
     .factory('Ranking', ['$resource', function($resource) {
       return $resource('/rest/ranking');
+    }])
+    .factory('RankingByTag', ['$resource', function($resource) {
+    	return $resource('/rest/rankings/tags/:tag');
     }])
     .factory('Player', ['$resource', function($resource) {
       return $resource('/rest/players/:player');
@@ -137,7 +144,10 @@ function MainController($scope, $rootScope, $resource, $location, $routeParams, 
 }
 
 function TablesController($scope, $rootScope, $resource, $location, $routeParams, Tables) {
-  $scope.tables = [{name: 'Park'}, {name: 'Albis'}, {name: 'Bern'}, {name: 'Skopje'}, {name: 'Rigi'}];
+  $scope.isTablesLoading = true;
+  $scope.tables = Tables.query({}, function() {
+	  $scope.isTablesLoading = false;
+  });
   
   $rootScope.backlink = false;
   
@@ -375,7 +385,8 @@ function SummaryController($scope, $rootScope, $resource, $routeParams, Summary,
   $scope.getSummary();
 }
 
-function RankingController($scope, $rootScope, $resource, $routeParams, Ranking, Badges) {
+function RankingController($scope, $rootScope, $resource, $routeParams, Ranking, Badges, Tables) {
+  
   $scope.predicate = [ '-successRate', '-goalPlusMinus'];
   $scope.isRankingLoading = true;
   $rootScope.backlink = false;
@@ -383,12 +394,34 @@ function RankingController($scope, $rootScope, $resource, $routeParams, Ranking,
     $scope.isRankingLoading = false;
     
   });
+  $scope.tables = Tables.query();
+  //extract this to a service to avoid duplication and provide caching
   $scope.badgeMap = Badges.get(function() {
     $scope.badgeList = [];
     angular.forEach($scope.badgeMap, function(key, value) {
       $scope.badgeList.push(key);
     });
   });
+}
+
+function RankingByTagController($scope, $rootScope, $resource, $routeParams, RankingByTag, Badges, Tables) {
+	$scope.tag = $routeParams.tag;
+	$scope.predicate = [ '-successRate', '-goalPlusMinus'];
+	$scope.isRankingLoading = true;
+	$rootScope.backlink = false;
+	$scope.rankings = RankingByTag.query({tag: $scope.tag}, function() {
+		$scope.isRankingLoading = false;
+		
+	});
+	
+	$scope.tables = Tables.query();
+	// extract this to a service to avoid duplication and provide caching
+	$scope.badgeMap = Badges.get(function() {
+		$scope.badgeList = [];
+		angular.forEach($scope.badgeMap, function(key, value) {
+			$scope.badgeList.push(key);
+		});
+	});
 }
 
 function PlayerController($scope, $rootScope, $routeParams, PlayerService, Player, TimeSeries, Badges) {

--- a/src/main/webapp/partials/ranking.html
+++ b/src/main/webapp/partials/ranking.html
@@ -1,6 +1,9 @@
 
 <h1>NFA Ranking</h1>
-
+<div>
+	Ranking: <a href="#/ranking">All</a>
+		<span ng-repeat="table in tables">, <a href="#/ranking/tag/{{table.name}}">{{table.name}}</a></span>
+</div>
 <div class="table-responsive">
 	<table class="table table-striped">
 		<thead>

--- a/src/main/webapp/partials/tables.html
+++ b/src/main/webapp/partials/tables.html
@@ -4,3 +4,6 @@
    <p class="lead">Pick the table for playing a match</p>
  </div>
 <button type="button"  ng-click="selectTable(table)" ng-repeat="table in tables" class="btn btn-primary btn-lg btn-block">{{table.name}}</button>
+<div ng-show="isTablesLoading">
+  <img src="images/ajax-loader.gif" /> Loading available tables...
+</div>


### PR DESCRIPTION
on the fly by tag. Tags can be tables, events, butterflies and zebras 
and moonbeams and fairy tales. 
Missing: 
- currently no UI to add tags to a game, except table
  Known issues:
- link from tag filtered rankings to player details shows overall player
  details
